### PR TITLE
add OAI-PMH generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,70 @@ by your site.
 `is_saving_sitemaps`: Determines if sitemaps will be written to disk (bool)
 
 `has_wellknown_at_root`: Where is the description document {.well-known/resourcesync} on the server (bool)
+
+
+## OAI-PMH Generator
+
+An OAI-PMH generator for py-resourcesync exists in `resourcesync/generators`, allowing institutions to bootstrap a ResourceSync-compatible repository using their existing OAI-PMH repository.
+
+The code snippets below use filesystem paths for institutions that will be using `httpd` to serve their ResourceSync documents.
+
+### Installation
+
+In addition to the setup instructions [above](#installation-from-source), do the following:
+
+```bash
+$ pip3 install beautifulsoup4 Sickle validators
+```
+
+#### Testing
+
+In order to run the tests for this generator, you'll also need to do:
+
+```bash
+$ pip3 install requests-mock
+```
+
+### Usage
+
+There must exist a directory at the path specified by `resource_dir`. For `httpd`:
+
+```bash
+$ mkdir /var/www/html/resourcesync/ # create a place for the ResourceSync documents
+```
+
+Then, with Python:
+
+```python
+from resourcesync.resourcesync import ResourceSync
+from resourcesync.generators.oaipmh_generator import OAIPMHGenerator
+
+httpd_document_root = '/var/www/html'
+resource_dir = 'resourcesync'
+collection_name = 'test'
+resourcesync_url = 'http://your-resourcecync-server.edu'
+
+# your-oaipmh-server may be the same as your-resourcesync-server
+oaipmh_base_url = 'http://your-oaipmh-server.edu/oai/provider'
+
+oaipmh_set = collection_name # or None, if the "set" parameter is not used in
+                             # the query string for ListIdentifiers and
+                             # ListRecords requests (i.e., each record set
+                             # has a distinct base URL)
+
+oaipmh_metadataprefix = 'oai_dc'
+
+my_generator = OAIPMHGenerator(params={
+    'oaipmh_base_url':       oaipmh_base_url,
+    'oaipmh_set':            oaipmh_set,
+    'oaipmh_metadataprefix': oaipmh_metadataprefix})
+
+rs = ResourceSync(generator=my_generator,
+                  strategy=0,
+                  resource_dir='{}/{}'.format(httpd_document_root, resource_dir),
+                  metadata_dir=collection_name,
+                  description_dir=httpd_document_root,
+                  url_prefix='{}/{}'.format(resourcesync_url, resource_dir),
+                  is_saving_sitemaps=True)
+rs.execute()
+```

--- a/resourcesync/generators/oaipmh_generator.py
+++ b/resourcesync/generators/oaipmh_generator.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+"""
+:samp:`An OAI-PMH Generator.`
+"""
+
+from resourcesync.core.generator import Generator
+from hashlib import md5
+from resync import Resource
+from sickle import Sickle
+from requests import get
+from bs4 import BeautifulSoup
+
+
+class OAIPMHGenerator(Generator):
+    """Generator class for using ResourceSync with OAI-PMH records.
+
+    This generator expects a dictionary supplied via the `params` kwarg with
+    the following keys set:
+
+    oaipmh_base_url         the base URL for OAI-PMH requests, to which query
+        parameters are appended to form the full request URL
+
+    oaipmh_set              the set argument, as defined in
+        https://www.openarchives.org/OAI/openarchivesprotocol.html#Set
+
+    oaipmh_metadataprefix   the metadata prefix argument, as defined in
+        https://www.openarchives.org/OAI/openarchivesprotocol.html#MetadataNamespaces
+    """
+    def __init__(self, params=None, rsxml=None):
+
+        Generator.__init__(self, params, rsxml=rsxml)
+
+    def generate(self):
+        """Returns a list of ResourceSync resources that each represent one
+        full OAI-PMH record (i.e., the result of a GetRecord request).
+        """
+
+        provider = Sickle(self.params['oaipmh_base_url'])
+        headers  = provider.ListIdentifiers(ignore_deleted=True,
+            set=self.params['oaipmh_set'],
+            metadataPrefix=self.params['oaipmh_metadataprefix'])
+
+        return list(map(self.oaipmh_header_to_resourcesync_resource, headers))
+
+    def oaipmh_header_to_resourcesync_resource(self, header):
+        """Maps an OAI-PMH record identifier to a ResourceSync Resource.
+
+        header              an instance of `sickle.models.Header`
+            https://sickle.readthedocs.io/en/latest/api.html#sickle.models.Header
+        """
+
+        soup       = BeautifulSoup(header.raw.encode('utf-8'), 'xml')
+        lastmod    = soup.header.datestamp.text
+        identifier = soup.identifier.text
+
+        uri = '{}?verb=GetRecord&identifier={}&metadataPrefix={}'.format(
+            self.params['oaipmh_base_url'],
+            identifier,
+            self.params['oaipmh_metadataprefix'])
+
+        # do a GET request for each record to retrieve the 'content-length'
+        r      = get(uri)
+        length = len(r.content)
+
+        # compute md5 of the GetRecord element (OAI-PMH responses include
+        # responseDate tags, so the md5 of the entire response is different for
+        # subsequent requests for the same record)
+        m       = md5()
+        element = str(BeautifulSoup(r.content, 'xml').GetRecord).encode('utf-8')
+        m.update(element)
+
+        return Resource(
+            uri=uri,
+            lastmod=lastmod,
+            md5=m.hexdigest(),
+            length=length,
+            mime_type="text/xml")

--- a/tests/test_oaipmh_generator.py
+++ b/tests/test_oaipmh_generator.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from resourcesync.resourcesync import ResourceSync
+from resourcesync.generators.oaipmh_generator import OAIPMHGenerator
+from requests_mock import mock
+from tests.test_oaipmh_generator_mock_responses import mock_responses
+import logging
+
+
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+class OAIPMHGeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.oaipmh_base_url         = "http://example.com/oai"
+        self.oaipmh_set              = "test"
+        self.oaipmh_metadataprefix   = "oai_dc"
+        self.oaipmh_generator_params = {
+            "oaipmh_base_url":       self.oaipmh_base_url,
+            "oaipmh_set":            self.oaipmh_set,
+            "oaipmh_metadataprefix": self.oaipmh_metadataprefix }
+
+        self.getrecord_url_template       = "{}?verb=GetRecord&identifier={}&metadataPrefix={}"
+        self.listidentifiers_url_template = "{}?verb=ListIdentifiers&set={}&metadataPrefix={}"
+        self.http_response_headers        = { "content-type": "text/xml" }
+
+    def test_generate(self):
+
+        with mock() as m:
+
+            test_num = 0
+
+            # create two records, A and B
+            getrecord_A_url     = self.getrecord_url_template.format(self.oaipmh_base_url, "A", self.oaipmh_metadataprefix)
+            getrecord_B_url     = self.getrecord_url_template.format(self.oaipmh_base_url, "B", self.oaipmh_metadataprefix)
+            listidentifiers_url = self.listidentifiers_url_template.format(self.oaipmh_base_url, self.oaipmh_set, self.oaipmh_metadataprefix)
+
+            m.get(getrecord_A_url,     text=mock_responses[test_num][getrecord_A_url],     headers=self.http_response_headers)
+            m.get(getrecord_B_url,     text=mock_responses[test_num][getrecord_B_url],     headers=self.http_response_headers)
+            m.get(listidentifiers_url, text=mock_responses[test_num][listidentifiers_url], headers=self.http_response_headers)
+
+            metadata = OAIPMHGenerator(params=self.oaipmh_generator_params).generate()
+            LOG.debug(metadata)
+
+            # save so we can track changes to record B
+            old_metadata = metadata
+
+            # expect two records in the metadata list
+            self.assertTrue(len(metadata) == 2)
+            self.assertTrue(len(list(filter(lambda x: x.uri == getrecord_A_url, metadata))) == 1)
+            self.assertTrue(len(list(filter(lambda x: x.uri == getrecord_B_url, metadata))) == 1)
+
+
+
+            test_num = 1
+
+            # delete record A, update record B, create record C
+            getrecord_A_url     = self.getrecord_url_template.format(self.oaipmh_base_url, "A", self.oaipmh_metadataprefix)
+            getrecord_B_url     = self.getrecord_url_template.format(self.oaipmh_base_url, "B", self.oaipmh_metadataprefix)
+            getrecord_C_url     = self.getrecord_url_template.format(self.oaipmh_base_url, "C", self.oaipmh_metadataprefix)
+            listidentifiers_url = self.listidentifiers_url_template.format(self.oaipmh_base_url, self.oaipmh_set, self.oaipmh_metadataprefix)
+
+            m.get(getrecord_A_url,     text=mock_responses[test_num][getrecord_A_url],     headers=self.http_response_headers)
+            m.get(getrecord_B_url,     text=mock_responses[test_num][getrecord_B_url],     headers=self.http_response_headers)
+            m.get(getrecord_C_url,     text=mock_responses[test_num][getrecord_C_url],     headers=self.http_response_headers)
+            m.get(listidentifiers_url, text=mock_responses[test_num][listidentifiers_url], headers=self.http_response_headers)
+
+            metadata = OAIPMHGenerator(params=self.oaipmh_generator_params).generate()
+            LOG.debug(metadata)
+
+            # compare md5 values of each version of record B to check for updates
+            old_md5 = list(filter(lambda x: x.uri == getrecord_B_url, old_metadata))[0].md5
+            new_md5 = list(filter(lambda x: x.uri == getrecord_B_url, metadata))[0].md5
+            updated_record_B = old_md5 != new_md5
+
+            # expect two records in the metadata list
+            # record A was deleted, record B was updated, record C was created
+            self.assertTrue(len(metadata) == 2)
+            self.assertTrue(len(list(filter(lambda x: x.uri == getrecord_A_url, metadata))) == 0)
+            self.assertTrue(len(list(filter(lambda x: x.uri == getrecord_B_url, metadata))) == 1 and updated_record_B)
+            self.assertTrue(len(list(filter(lambda x: x.uri == getrecord_C_url, metadata))) == 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_oaipmh_generator_mock_responses.py
+++ b/tests/test_oaipmh_generator_mock_responses.py
@@ -1,0 +1,189 @@
+# `mock_responses` is a list of dictionaries, indexed by the test number (in `test_oaipmh_generator.py`) in which they're referenced.
+# Each dictionary maps mock HTTP GET target URLs to the corresponding mock text/xml response body.
+
+mock_responses = [
+    {
+        "http://example.com/oai?verb=GetRecord&identifier=A&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-02T00:00:00Z</responseDate>
+  <request verb="GetRecord" metadataPrefix="oai_dc" identifier="A">http://example.com/oai</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>A</identifier>
+        <datestamp>1970-01-01T00:00:00Z</datestamp>
+      </header>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                                       http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>test</dc:title>
+        </oai_cd:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+        """,
+
+        "http://example.com/oai?verb=GetRecord&identifier=B&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-02T00:00:00Z</responseDate>
+  <request verb="GetRecord" metadataPrefix="oai_dc" identifier="B">http://example.com/oai</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>B</identifier>
+        <datestamp>1970-01-01T00:00:00Z</datestamp>
+      </header>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                                       http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>test</dc:title>
+        </oai_cd:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+        """,
+
+        "http://example.com/oai?verb=ListIdentifiers&set=test&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-02T00:00:00Z</responseDate>
+  <request verb="ListIdentifiers" metadataPrefix="oai_dc">http://example.com/oai</request>
+  <ListIdentifiers>
+    <header>
+      <identifier>A</identifier>
+      <datestamp>1970-01-01T00:00:00Z</datestamp>
+      <setSpec>test</setSpec>
+    </header>
+    <header>
+      <identifier>B</identifier>
+      <datestamp>1970-01-01T00:00:00Z</datestamp>
+      <setSpec>test</setSpec>
+    </header>
+  </ListIdentifiers>
+</OAI-PMH>
+        """
+    },
+    {
+        "http://example.com/oai?verb=GetRecord&identifier=A&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-04T00:00:00Z</responseDate>
+  <request verb="GetRecord" metadataPrefix="oai_dc" identifier="A">http://example.com/oai</request>
+  <GetRecord>
+    <record>
+      <header status="deleted">
+        <identifier>A</identifier>
+        <datestamp>1970-01-03T00:00:00Z</datestamp>
+      </header>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+        """,
+
+        "http://example.com/oai?verb=GetRecord&identifier=B&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-04T00:00:00Z</responseDate>
+  <request verb="GetRecord" metadataPrefix="oai_dc" identifier="B">http://example.com/oai</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>B</identifier>
+        <datestamp>1970-01-03T00:00:00Z</datestamp>
+      </header>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                                       http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>update</dc:title>
+        </oai_cd:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+        """,
+
+        "http://example.com/oai?verb=GetRecord&identifier=C&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-04T00:00:00Z</responseDate>
+  <request verb="GetRecord" metadataPrefix="oai_dc" identifier="C">http://example.com/oai</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>C</identifier>
+        <datestamp>1970-01-03T00:00:00Z</datestamp>
+      </header>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                                       http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+          <dc:title>create</dc:title>
+        </oai_cd:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+        """,
+
+        "http://example.com/oai?verb=ListIdentifiers&set=test&metadataPrefix=oai_dc": """
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
+                             http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+  <responseDate>1970-01-04T00:00:00Z</responseDate>
+  <request verb="ListIdentifiers" metadataPrefix="oai_dc">http://example.com/oai</request>
+  <ListIdentifiers>
+    <header status="deleted">
+      <identifier>A</identifier>
+      <datestamp>1970-01-03T00:00:00Z</datestamp>
+      <setSpec>test</setSpec>
+    </header>
+    <header>
+      <identifier>B</identifier>
+      <datestamp>1970-01-03T00:00:00Z</datestamp>
+      <setSpec>test</setSpec>
+    </header>
+    <header>
+      <identifier>C</identifier>
+      <datestamp>1970-01-03T00:00:00Z</datestamp>
+      <setSpec>test</setSpec>
+    </header>
+  </ListIdentifiers>
+</OAI-PMH>
+        """
+    }
+]


### PR DESCRIPTION
This generator will allow institutions to bootstrap a ResourceSync-compatible repository using their existing OAI-PMH repository.

I've added supporting documentation with installation instructions and example usage to the README.md as well as tests that can be run with `python3 -m unittest tests/test_oaipmh_generator.py`.