### PR TITLE
fixes https://github.com/resourcesync/py-resourcesync/issues/11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,6 @@ setup(
     license=license,
     zip_safe=False,
     packages=find_packages(exclude=("tests", "docs")),
-    install_requires=["validators", "resync", "bs4", "sickle", "elasticsearch>=1.0.0,<2.0.0"],
+    install_requires=["validators", "resync>=1.0.8", "bs4", "sickle", "elasticsearch>=1.0.0,<2.0.0"],
     test_requires=["pytest", "bs4", "sickle", "requests_mock", "elasticsearch>=1.0.0,<2.0.0", "urllib3_mock"]
 )


### PR DESCRIPTION
Currently, SitemapIndex generation doesn't work as expected, due to a bug in `resync` [that has since been fixed by the changes in this PR](https://github.com/resync/resync/pull/32) -- compare the added unit test in that repo to the [executors](https://github.com/resourcesync/py-resourcesync/commit/664b6ee7510e49413bb620e3807c47546135d136#diff-2f887fbb5956866b6cf3ef5de42b3db9R37). As I noted in #11, the bugfix is now published on PyPI as version 1.0.8, and it seems that `setup.py` should require at least that version from now on.