### PR TITLE
Changes directly from Generator

### DIFF
--- a/resourcesync/executor/changelist.py
+++ b/resourcesync/executor/changelist.py
@@ -71,8 +71,12 @@ class ChangeListExecutor(Executor, metaclass=ABCMeta):
             self.previous_resources = {}
 
             # search for resourcelists
-            self.resourcelist_files = sorted(glob(self.param.abs_metadata_path("resourcelist_*.xml")))
-            for rl_file_name in self.resourcelist_files:
+            self.resourcelist_files = sorted(glob(self.param.abs_metadata_path("resourcelist-index.xml")))
+            if len(self.resourcelist_files) == 0:
+                self.resourcelist_files = sorted(glob(self.param.abs_metadata_path("resourcelist_*.xml")))
+
+            if len(self.resourcelist_files) > 0:
+                rl_file_name = self.resourcelist_files[0]
                 resourcelist = ResourceList()
                 with open(rl_file_name, "r", encoding="utf-8") as rl_file:
                     sm = Sitemap()

--- a/resourcesync/executor/changelist.py
+++ b/resourcesync/executor/changelist.py
@@ -15,9 +15,11 @@ from resync import ChangeList
 from resync import Resource
 from resync import ResourceList
 from resync.sitemap import Sitemap
+
 from resourcesync.core.executors import Executor, SitemapData, ExecutorEvent
 from resourcesync.parameters.enum import Capability
 from resourcesync.parameters.parameters import Parameters
+from resourcesync.rsxml.rsxml import RsXML
 
 
 class ChangeListExecutor(Executor, metaclass=ABCMeta):
@@ -80,45 +82,24 @@ class ChangeListExecutor(Executor, metaclass=ABCMeta):
                 if self.date_resourcelist_completed is None:
                     self.date_resourcelist_completed = resourcelist.md_at
 
-                self.previous_resources.update({resource.uri: resource for resource in resourcelist.resources})
-
             # search for changelists
             self.changelist_files = sorted(glob(self.param.abs_metadata_path("changelist_*.xml")))
-            for cl_file_name in self.changelist_files:
-                changelist = ChangeList()
-                with open(cl_file_name, "r", encoding="utf-8") as cl_file:
-                    sm = Sitemap()
-                    sm.parse_xml(cl_file, resources=changelist)
-
-                for resource in changelist.resources:
-                    if resource.change == "created" or resource.change == "updated":
-                        self.previous_resources.update({resource.uri: resource})
-                    elif resource.change == "deleted" and resource.uri in self.previous_resources:
-                        del self.previous_resources[resource.uri]
 
     def changelist_generator(self, resource_metadata: [Resource]) -> iter:
 
         def generator(changelist=None) -> [SitemapData, ChangeList]:
-            resource_generator = self.resource_generator()
-            self.update_previous_state()
-            prev_r = self.previous_resources
-            curr_r = {resource.uri: resource for count, resource in resource_generator(resource_metadata)}
-            created = [r for r in curr_r.values() if r.uri not in prev_r]
-            updated = [r for r in curr_r.values() if r.uri in prev_r and r.md5 != prev_r[r.uri].md5]
-            deleted = [r for r in prev_r.values() if r.uri not in curr_r]
-            unchang = [r for r in curr_r.values() if r.uri in prev_r and r.md5 == prev_r[r.uri].md5]
-
-            # remove lastmod from deleted resource metadata
-            for resource in deleted:
-                resource.lastmod = None
+            change_generator = self.resource_generator()
+            changes = [change for count, change in change_generator(resource_metadata)]
+            created = [c for c in changes if c.change == 'created']
+            updated = [c for c in changes if c.change == 'updated']
+            deleted = [c for c in changes if c.change == 'deleted']
 
             num_created = len(created)
             num_updated = len(updated)
             num_deleted = len(deleted)
             tot_changes = num_created + num_updated + num_deleted
             self.observers_inform(self, ExecutorEvent.found_changes, created=num_created, updated=num_updated,
-                                  deleted=num_deleted, unchanged=len(unchang))
-            all_changes = {"created": created, "updated": updated, "deleted": deleted}
+                                  deleted=num_deleted)
 
             ordinal = self.find_ordinal(Capability.changelist.name)
 
@@ -131,23 +112,20 @@ class ChangeListExecutor(Executor, metaclass=ABCMeta):
                     ordinal += 1
                     resource_count = 0
 
-            for kv in all_changes.items():
-                for resource in kv[1]:
-                    if changelist is None:
-                        changelist = ChangeList()
-                        changelist.md_from = self.date_changelist_from
+            for change in changes:
+                if changelist is None:
+                    changelist = ChangeList()
+                    changelist.md_from = self.date_changelist_from
 
-                    resource.change = kv[0] # type of change: created, updated or deleted
-                    resource.md_datetime = self.date_start_processing
-                    changelist.add(resource)
-                    resource_count += 1
+                changelist.add(change)
+                resource_count += 1
 
-                    # under conditions: yield the current changelist
-                    if resource_count % self.param.max_items_in_list == 0:
-                        ordinal += 1
-                        sitemap_data = self.finish_sitemap(ordinal, changelist)
-                        yield sitemap_data, changelist
-                        changelist = None
+                # under conditions: yield the current changelist
+                if resource_count % self.param.max_items_in_list == 0:
+                    ordinal += 1
+                    sitemap_data = self.finish_sitemap(ordinal, changelist)
+                    yield sitemap_data, changelist
+                    changelist = None
 
             # under conditions: yield the current and last changelist
             if changelist and tot_changes > 0:

--- a/tests/test_changelist.py
+++ b/tests/test_changelist.py
@@ -26,7 +26,8 @@ class ChangeGenerator(Generator):
             lastmod="2017-06-14",
             md5=m.hexdigest(),
             length=len(body),
-            mime_type="application/xml"
+            mime_type="application/xml",
+            change="updated"
         )
         return [rm]
 

--- a/tests/test_resourcesync.py
+++ b/tests/test_resourcesync.py
@@ -11,7 +11,7 @@ import os
 from resourcesync.parameters.parameters import ParameterUtils
 
 
-class TestReSync(ResourceSync):
+class TestResources(ResourceSync):
     def get_resource_list(self):
         url = "http://www.resourcesync.org"
         m = md5()
@@ -27,6 +27,22 @@ class TestReSync(ResourceSync):
         return [rm]
 
 
+class TestChanges(ResourceSync):
+    def get_resource_list(self):
+        url = "http://www.resourcesync.org"
+        m = md5()
+        m.update(url.encode("utf8"))
+
+        rm = Resource(
+            uri=url,
+            lastmod="2016-10-01",
+            md5=m.hexdigest(),
+            length=20,
+            mime_type="application/xml",
+            change="updated"
+        )
+        return [rm]
+
 eg_gen = EgGenerator()
 
 
@@ -39,17 +55,17 @@ class ResourceSyncTest(unittest.TestCase):
             pass
 
     def test_resourcelist(self):
-        rs = TestReSync(generator=eg_gen, strategy=0,
+        rs = TestResources(generator=eg_gen, strategy=0,
                         metadata_dir="test_md")
         rs.execute()
 
     def test_newchangelist(self):
-        rs = TestReSync(generator=eg_gen, strategy=1,
+        rs = TestChanges(generator=eg_gen, strategy=1,
                         metadata_dir="test_md")
         rs.execute()
 
     def test_incchangelist(self):
-        rs = TestReSync(generator=eg_gen, strategy=2,
+        rs = TestChanges(generator=eg_gen, strategy=2,
                         metadata_dir="test_md")
         rs.execute()
 


### PR DESCRIPTION
Addressing issue #18 , this is just one of the possible approaches to handle changes in a scalable way. Feedback or different approaches more than welcome.

I also would like to mention that [here](https://github.com/resourcesync/py-resourcesync/blob/7f268e7b563b9781e9647e44d8584e667cad89c3/resourcesync/executor/changelist.py#L141) we use the `md_datetime` value of the RS 1.1 specs. Unfortunately, this is not supported by the standard `resync` library, indeed `rspub-core` was using a [forked version](https://github.com/EHRI/resync) which supports it. Either we use the same fork or we just don't use `md_datetime` until `resync` is updated to RS 1.1 (see [this issue](https://github.com/resync/resync/issues/24)).